### PR TITLE
Add OpenBB (with link) to OSS Capital

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All VCs in the list are sorted by 1) investment stage and 2) name (alphabetical 
 [Firstminute Capital](https://www.firstminute.capital/) | Pre-Seed/Seed | $0.25-5M | UK | Element, n8n, Nuxt.js, Quickwit |
 [Fly Ventures](https://fly.vc/) | Pre-Seed/Seed | $1-3M | Germany | GitGuardian, Evidently AI, Objectiv |
 [Lunar Ventures](https://lunar.vc/) | Pre-Seed/Seed | $0.3-1M | Germany | deepset, WASP, nannyML |
-[OSS Capital](https://oss.capital/) | Pre-Seed/Seed | $0.1-6M | US | Rocket.chat, Cal.com, Forem, Remix |
+[OSS Capital](https://oss.capital/) | Pre-Seed/Seed | $0.1-6M | US | Rocket.chat, Cal.com, Forem, Remix, [OpenBB](www.openbb.co) |
 [Open Core Ventures](https://opencoreventures.com/) | Pre-Seed/Seed | $0.1-2M | US | Fleet, FlowForge, Mermaid Chart |
 [Seedcamp](https://seedcamp.com/) | Pre-Seed/Seed | $0.2-0.5M | UK | Meilisearch, Medusa,  Cerbos |
 [Y Combinator](https://www.ycombinator.com/) | Pre-Seed/Seed | $0.5M | US | Apollo, Posthog, MindsDB |


### PR DESCRIPTION
OpenBB being one of the biggest checks of OSS Capital, I think it makes sense to add to the list.

I also thought that adding a link to the website or even GitHub project (e.g. https://github.com/OpenBB-finance/OpenBBTerminal/) could add an incentive to the companies to update the list (which is what I'm doing now).

Let me know if this is ok 😄 